### PR TITLE
DictFragmentのリストを右に拡張する

### DIFF
--- a/android/app/src/main/res/layout/fragment_dict.xml
+++ b/android/app/src/main/res/layout/fragment_dict.xml
@@ -33,9 +33,10 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:src="@drawable/ic_quiz"
+            android:layout_marginEnd="36dp"
             app:fabSize="mini"
             app:layout_constraintBottom_toBottomOf="@+id/titleLabel"
-            app:layout_constraintStart_toEndOf="@+id/refreshLayout"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="@+id/titleLabel" />
 
         <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
@@ -44,7 +45,7 @@
             android:layout_height="0dp"
             android:layout_marginStart="16dp"
             android:layout_marginTop="8dp"
-            android:layout_marginEnd="76dp"
+            android:layout_marginEnd="36dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -55,6 +56,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:orientation="vertical"
+                android:clipToPadding="false"
+                android:paddingBottom="120dp"
                 app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                 tools:listitem="@layout/item_sentence" />
         </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>


### PR DESCRIPTION
# Description
DictFragmentのリストを右に拡張して下に余白を作ることにより，マイクボタンで見えない部分を担保する

# Implementation
clipToPaddingをfalseにしてRecyclerViewの下にPaddingをついか

# Review Points

# Screenshots
<img width="250" src="https://user-images.githubusercontent.com/6965122/67792030-cc9a3f80-fabb-11e9-976b-67c69160eab1.gif"/>

# Links


